### PR TITLE
bugfix: after attached to tracee, the traced program is still running

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ func main() {
 }
 
 func processSignals() {
-
 	ch := make(chan os.Signal, 16)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGURG)
 

--- a/pkg/target/thread.go
+++ b/pkg/target/thread.go
@@ -1,12 +1,7 @@
 package target
 
-import (
-	"syscall"
-)
-
 // Thread 线程信息
 type Thread struct {
-	Tid     int                // thread ID
-	Status  syscall.WaitStatus // wait status
-	Process *DebuggedProcess   // process this thread belongs to
+	Tid     int              // thread ID
+	Process *DebuggedProcess // process this thread belongs to
 }


### PR DESCRIPTION
Before, all ptrace requests and responses go through via the DebuggedProcess's chan fields.
There's an bug here, goroutines requests the ptrace may get the not matched responses via p.rspCh,
so we reimplement the ExecPtrace method to wrap the argument `fn() error` into a instance of 
`type ptraceRequest struct`, and the ptrace response will be sent back via the `ptraceRequest.errCh`.

After that, we rewrite the code to only put the `syscall.Ptrace...()` into the `ExecPtrace(...) method`,
so we can avoid the thread blocked by calling syscalls on the same locked thread by goroutine. Before 
this fix, the locked thread maybe blocked in syscall like syscall.Wait, and won't receive ptrace request
or send response back...weired behaviour.

